### PR TITLE
Retry transient HTTP errors

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.4.0
+-----
+
+* Retry transient HTTP errors in project creation
+* Existing git repos can now be 'hooked up'
+
 0.3.0
 -----
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.3.0
+-----
+
+* Upgrade to Gitlab API v4
+
 0.2.0
 -----
 

--- a/datakit_gitlab/__init__.py
+++ b/datakit_gitlab/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Serdar Tumgoren"""
 __email__ = 'stumgoren@ap.org'
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 from .commands.integrate import Integrate
 from .commands import issues

--- a/datakit_gitlab/commands/integrate.py
+++ b/datakit_gitlab/commands/integrate.py
@@ -25,13 +25,13 @@ class Integrate(CommandHelpers, Command):
                 Git.init()
                 Git.add()
                 Git.commit()
-                resp = project.create()
-                Git.remote_add_origin(resp.ssh_url_to_repo)
-                Git.push()
-                alert_msg = 'Project created: \n\t{}'.format(resp.web_url)
-                self.log.info(alert_msg)
             else:
                 self.log.info("Repo has already been initialized!")
+            resp = project.create()
+            Git.remote_add_origin(resp.ssh_url_to_repo)
+            Git.push()
+            alert_msg = 'Project created: \n\t{}'.format(resp.web_url)
+            self.log.info(alert_msg)
 
     def get_project_slug(self):
         return os.path.basename(os.getcwd())

--- a/datakit_gitlab/gitlab_project.py
+++ b/datakit_gitlab/gitlab_project.py
@@ -22,11 +22,15 @@ class GitlabProject:
         return len(self.client.projects.list(search=self.project_slug)) > 0
 
     def create(self):
-        proj = self.client.projects.create({
         grp = self.client.groups.list(search=self.namespace)[0]
+        proj_metadata = {
             'name': self.project_slug,
             'namespace_id': grp.id
-        })
+        }
+        proj = self.client.projects.create(
+            proj_metadata,
+            retry_transient_errors = True
+        )
         return proj
 
     def add_issue(self, opts):

--- a/datakit_gitlab/gitlab_project.py
+++ b/datakit_gitlab/gitlab_project.py
@@ -22,8 +22,8 @@ class GitlabProject:
         return len(self.client.projects.list(search=self.project_slug)) > 0
 
     def create(self):
-        grp = self.client.groups.get(self.namespace)
         proj = self.client.projects.create({
+        grp = self.client.groups.list(search=self.namespace)[0]
             'name': self.project_slug,
             'namespace_id': grp.id
         })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cliff==2.3.0
 datakit-core==0.2.1
-python-gitlab==0.19
+python-gitlab==2.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 requirements = [
     'cliff',
     'datakit-core',
-    'python-gitlab>=1.5.0'
+    'python-gitlab>=2.5.0'
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ test_requirements = [
 
 setup(
     name='datakit-gitlab',
-    version='0.3.0',
+    version='0.4.0',
     description="Commands to manage project integration with Gitlab.",
     long_description=__doc__,
     author="Serdar Tumgoren",


### PR DESCRIPTION
In addition to retrying transient HTTP errors, I did some small cleanup:

- Moved over to v4 API for group searching as well
- Double checked version numbers across the project
- Moved the remote configuration and push logic out of the check for the local repo